### PR TITLE
Add terminal AI tools browser with tests

### DIFF
--- a/DIFF_20250810_204539.md
+++ b/DIFF_20250810_204539.md
@@ -1,0 +1,4 @@
+## Changes on 2025-08-10 20:45:39 UTC
+- Added `ai_tools_tui.py` providing a terminal interface to browse and open AI tool links parsed from README.
+- Added tests in `tests/test_parser.py` ensuring parser detects categories and tool structure.
+- Updated `README.md` with instructions for running the terminal interface.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Welcome to Awesome AI Tools! Dive into my curated list of AI list, featuring top
 
 We publish regular updates of this repo in the [Altern Newsletter](http://newsletter.altern.ai). [Subscribe](http://newsletter.altern.ai) for the latest AI news and discover the best AI tools.
 
+## Terminal Interface
+
+Run the terminal interface to explore the tools from your shell:
+
+```bash
+python ai_tools_tui.py
+```
+
+Follow the prompts to choose a category and open tool links.
+
 ## Contents
 
 - [🌟 Editor's Choice](#editors-choice)

--- a/RECOMMENDATIONS_20250810_204539.md
+++ b/RECOMMENDATIONS_20250810_204539.md
@@ -1,0 +1,5 @@
+## Recommendations from 2025-08-10 20:45:39 UTC
+- Integrate a search feature to quickly locate tools by name.
+- Cache parsed README data to avoid reparsing on each run.
+- Add unit tests for interactive CLI via mocking user input.
+- Consider fetching updates from remote source to keep tool list current without manual README edits.

--- a/ai_tools_tui.py
+++ b/ai_tools_tui.py
@@ -1,0 +1,74 @@
+import re
+import webbrowser
+from pathlib import Path
+
+README_PATH = Path(__file__).with_name('README.md')
+
+def parse_readme(path: Path = README_PATH):
+    """Parse README and return mapping of category to list of tools.
+
+    Each tool is represented as a dict with keys: name, link, description.
+    """
+    categories = {}
+    current_cat = None
+    tool_pattern = re.compile(r"- \[(?P<name>[^\]]+)\]\((?P<link>[^)]+)\)(?: - (?P<desc>.*))?")
+    header_pattern = re.compile(r"^(##+)\s+(.*)")
+
+    with path.open(encoding='utf-8') as f:
+        for line in f:
+            header_match = header_pattern.match(line)
+            if header_match:
+                level = len(header_match.group(1))
+                name = header_match.group(2).strip()
+                if level >= 2:
+                    current_cat = name
+                    categories[current_cat] = []
+                continue
+            if current_cat is None:
+                continue
+            line = line.strip()
+            if not line.startswith('- ['):
+                continue
+            match = tool_pattern.match(line)
+            if match:
+                categories[current_cat].append(match.groupdict())
+    return categories
+
+def run_cli():
+    data = parse_readme()
+    categories = list(data.keys())
+    while True:
+        print('\nAvailable categories:')
+        for idx, name in enumerate(categories, 1):
+            print(f"{idx}. {name}")
+        print('0. Exit')
+        choice = input('Select a category: ').strip()
+        if choice == '0':
+            break
+        if not choice.isdigit() or int(choice) < 1 or int(choice) > len(categories):
+            print('Invalid choice. Try again.')
+            continue
+        cat = categories[int(choice) - 1]
+        tools = data[cat]
+        while True:
+            print(f"\nTools in {cat}:")
+            for idx, tool in enumerate(tools, 1):
+                print(f"{idx}. {tool['name']}")
+            print('0. Back')
+            t_choice = input('Select a tool: ').strip()
+            if t_choice == '0':
+                break
+            if not t_choice.isdigit() or int(t_choice) < 1 or int(t_choice) > len(tools):
+                print('Invalid choice. Try again.')
+                continue
+            tool = tools[int(t_choice) - 1]
+            print(f"\n{tool['name']}")
+            if tool.get('desc'):
+                print(tool['desc'])
+            print(f"Link: {tool['link']}")
+            open_choice = input('Open link in browser? (y/N): ').strip().lower()
+            if open_choice == 'y':
+                webbrowser.open(tool['link'])
+
+if __name__ == '__main__':
+    run_cli()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,13 @@
+import ai_tools_tui
+
+def test_parse_readme_has_editors_choice():
+    data = ai_tools_tui.parse_readme()
+    assert "Editor's Choice" in data
+
+def test_parse_readme_first_tool_structure():
+    data = ai_tools_tui.parse_readme()
+    first_category = next(iter(data.values()))
+    assert isinstance(first_category, list)
+    if first_category:  # ensure not empty
+        tool = first_category[0]
+        assert set(tool.keys()) == {"name", "link", "desc"}


### PR DESCRIPTION
## Summary
- add `ai_tools_tui.py` parsing README to browse tools in terminal
- document usage in README
- add parser tests and documentation files

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899047f4914832aafca07768a93060c

## Summary by Sourcery

Add a TUI for exploring AI tools by parsing the README and include tests plus documentation for running the interface

New Features:
- Introduce ai_tools_tui.py providing a terminal interface to browse and open AI tool links parsed from the README

Documentation:
- Document terminal interface usage in README

Tests:
- Add tests for parse_readme to verify category detection and tool structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a terminal-based interface for browsing and opening AI tool links directly from the command line.
* **Documentation**
  * Updated the README with instructions for using the new terminal interface.
* **Tests**
  * Added tests to verify correct parsing of categories and tool structure from the README.
* **Chores**
  * Added a recommendations document outlining potential future improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->